### PR TITLE
Build with jack

### DIFF
--- a/calf-build-fix.patch
+++ b/calf-build-fix.patch
@@ -1,0 +1,17 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 794e668..7a73db6 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -32,10 +32,10 @@ endif
+ AM_CXXFLAGS += $(GLIB_DEPS_CFLAGS)
+ noinst_PROGRAMS += calfmakerdf
+ calfmakerdf_SOURCES = makerdf.cpp
+-calfmakerdf_LDADD = calf.la
++calfmakerdf_LDADD = calf.la $(JACK_DEPS_LIBS)
+ 
+ calfbenchmark_SOURCES = benchmark.cpp
+-calfbenchmark_LDADD = calf.la
++calfbenchmark_LDADD = calf.la $(JACK_DEPS_LIBS)
+ 
+ calf_la_SOURCES = audio_fx.cpp analyzer.cpp lv2wrap.cpp metadata.cpp modules_tools.cpp modules_delay.cpp modules_comp.cpp modules_limit.cpp modules_dist.cpp modules_filter.cpp modules_mod.cpp modules_pitch.cpp fluidsynth.cpp giface.cpp monosynth.cpp organ.cpp osctl.cpp plugin.cpp preset.cpp synth.cpp utils.cpp wavetable.cpp modmatrix.cpp
+ calf_la_LIBADD = $(FLUIDSYNTH_DEPS_LIBS) $(GLIB_DEPS_LIBS) 

--- a/org.freedesktop.LinuxAudio.Plugins.Calf.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Calf.json
@@ -24,6 +24,7 @@
         "*.la"
     ],
     "modules": [
+        "shared-modules/linux-audio/jack2.json",
         "shared-modules/linux-audio/fluidsynth2-static.json",
         "shared-modules/linux-audio/lv2.json",
         {

--- a/org.freedesktop.LinuxAudio.Plugins.Calf.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Calf.json
@@ -1,9 +1,9 @@
 {
     "id": "org.freedesktop.LinuxAudio.Plugins.Calf",
-    "branch": "21.08",
+    "branch": "22.08",
     "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
-    "runtime-version": "21.08",
-    "sdk": "org.freedesktop.Sdk//21.08",
+    "runtime-version": "stable",
+    "sdk": "org.freedesktop.Sdk//22.08",
     "build-extension": true,
     "appstream-compose": false,
     "build-options": {

--- a/org.freedesktop.LinuxAudio.Plugins.Calf.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Calf.json
@@ -61,6 +61,10 @@
                     }
                 },
                 {
+                    "type": "patch",
+                    "path": "calf-build-fix.patch"
+                },
+                {
                     "type": "file",
                     "path": "org.freedesktop.LinuxAudio.Plugins.Calf.metainfo.xml"
                 }


### PR DESCRIPTION
Plugins currently crash in some hosts with error message: `/app/extensions/Plugins/lv2/calf.lv2/calf.so: undefined symbol: jack_set_buffer_size_callback)`

hopefully this fixes it