### PR TITLE
Build with jack

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.Calf.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Calf.json
@@ -24,6 +24,7 @@
         "*.la"
     ],
     "modules": [
+        "shared-modules/linux-audio/jack2.json",
         "shared-modules/linux-audio/fluidsynth2-static.json",
         "shared-modules/linux-audio/lv2.json",
         {


### PR DESCRIPTION
Plugins currently crash in some hosts with error message:
`/app/extensions/Plugins/lv2/calf.lv2/calf.so: undefined symbol: jack_set_buffer_size_callback)`

hopefully this fixes it
