### PR TITLE
switch fluidsynth2 to non static

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.Calf.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Calf.json
@@ -24,7 +24,7 @@
         "*.la"
     ],
     "modules": [
-        "shared-modules/linux-audio/fluidsynth2-static.json",
+        "shared-modules/linux-audio/fluidsynth2.json",
         "shared-modules/linux-audio/lv2.json",
         {
             "name": "calf",


### PR DESCRIPTION
Fixes https://github.com/flathub/org.freedesktop.LinuxAudio.Plugins.Calf/issues/8 (tested in Carla)

I am well aware of this:
![grafik](https://user-images.githubusercontent.com/12885163/211168028-3739ff40-7edc-4e6c-bced-b056d5fe0e77.png)

... which is why I'm not sure if this is a great idea. However, I haven't found any other way to fix the problem.